### PR TITLE
Implement Code Plaza VS Code extension scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+out/
+*.vsix
+npm-debug.log*
+.vscode-test/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,143 @@
-# code-plaza
+# Code Plaza
+
+Code Plaza は、VS Code のサイドバーに仲間が集まる「広場」を表示する拡張機能です。チームメンバーはお気に入りのドット絵アバターとプロフィールを設定し、エディタを開いている間は自動的に広場へ参加します。誰がオンラインなのかを一目で把握でき、初めて出会うメンバーとすれ違うたびに経験値が貯まります。
+
+## 主な機能
+
+- **プロフィール編集**: 名前・アバター・一言コメントを設定し、いつでも編集可能。
+- **広場ビュー**: アバターがランダムに移動し、アクティブ/スリープ状態を表示。ホバーで一言コメントがポップアップします。
+- **セッション管理**: VS Code の起動と同時にセッションを作成し、Firebase Firestore にハートビートを送信して状態を更新します。
+- **すれ違い経験値**: 初めて挨拶するメンバーを検知して経験値を付与し、レベルアップを表示します。
+
+## プロジェクト構成
+
+```
+.
+├── package.json
+├── tsconfig.json
+├── esbuild.config.js
+├── src/
+│   ├── extension.ts        # 拡張機能のエントリーポイント
+│   ├── firestore.ts        # Firestore アクセスとモック実装
+│   └── messaging.ts        # WebView と拡張間のメッセージ定義
+├── webview-ui/
+│   ├── index.html          # WebView のベース HTML
+│   ├── index.tsx           # React アプリのエントリーポイント
+│   ├── components/
+│   │   ├── Arena.tsx       # 広場画面
+│   │   ├── Avatar.tsx      # アバター表示
+│   │   └── Profile.tsx     # プロフィール編集画面
+│   ├── hooks/
+│   │   └── useAvatars.ts   # アバター定義
+│   ├── styles/
+│   │   └── arena.css       # 共通スタイル
+│   └── assets/             # ドット絵アバター（SVG）
+└── media/
+    └── icon.svg            # アクティビティバーのアイコン
+```
+
+## 必要環境
+
+- Node.js v18 以上
+- VS Code v1.85 以上
+- Firebase プロジェクト（Firestore 有効化済み）
+
+## セットアップ手順
+
+1. リポジトリを取得します。
+
+   ```bash
+   git clone https://github.com/your-org/code-plaza.git
+   cd code-plaza
+   ```
+
+2. 依存関係をインストールします。
+
+   ```bash
+   npm install
+   ```
+
+3. `src/firestore.ts` の `firebaseConfig` に Firebase の設定値を入力します。
+
+   ```ts
+   const firebaseConfig = {
+     apiKey: '<YOUR_API_KEY>',
+     authDomain: '<YOUR_PROJECT_ID>.firebaseapp.com',
+     projectId: '<YOUR_PROJECT_ID>',
+     storageBucket: '<YOUR_PROJECT_ID>.appspot.com',
+     messagingSenderId: '<YOUR_SENDER_ID>',
+     appId: '<YOUR_APP_ID>',
+   };
+   ```
+
+   > ⚠️ Firebase の設定が空の場合、拡張機能はモックデータで動作し、実際の同期は行われません。
+
+4. ビルドを実行して `out/` に成果物を出力します。
+
+   ```bash
+   npm run build
+   ```
+
+5. 開発モードでホットリロードを開始します。VS Code で `F5` を押すと拡張機能が起動します。
+
+   ```bash
+   npm run watch
+   ```
+
+   デバッグ用の VS Code ウィンドウが立ち上がり、サイドバーに **Code Plaza** が表示されます。
+
+6. 配布用 VSIX ファイルを生成します。
+
+   ```bash
+   npm run package
+   ```
+
+   `code-plaza-x.x.x.vsix` が出力されます。
+
+## Firestore データ構造
+
+### `users`
+
+```json
+users/{uid} = {
+  "name": "Fujii",
+  "avatar_code": "apple",
+  "level": 3,
+  "message": "今日もがんばろう！",
+  "exp": 1200
+}
+```
+
+### `sessions`
+
+```json
+sessions/{uid} = {
+  "userRef": "users/{uid}",
+  "lastHeartbeat": "2025-09-23T10:15:00Z",
+  "greetedToday": ["uid1", "uid2"],
+  "greetedDate": "2025-09-23"
+}
+```
+
+- `active`: `lastHeartbeat` から 15 分以内
+- `sleeping`: 15〜30 分
+- `exit`: 30 分以上経過（クライアント側では表示しません）
+
+## 開発メモ
+
+- Firestore の設定に失敗した場合、自動的にモックモードへ切り替わり、VS Code 内のみでデータが保持されます。
+- すれ違い時の経験値は 120 pt を加算し、300 pt ごとにレベルアップします。必要に応じて `src/firestore.ts` の計算式を調整してください。
+- WebView 側は React で構成されており、`webview-ui` ディレクトリに UI コンポーネントがまとまっています。
+
+## コマンド一覧
+
+| コマンド             | 説明                               |
+| -------------------- | ---------------------------------- |
+| `npm run build`      | 拡張機能と WebView の一括ビルド     |
+| `npm run watch`      | 開発用ウォッチ（HTML 自動コピー付） |
+| `npm run package`    | VSIX パッケージ生成                |
+| `npm run lint`       | TypeScript の型チェック             |
+
+## ライセンス
+
+MIT License

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,0 +1,84 @@
+const esbuild = require('esbuild');
+const fs = require('fs');
+const path = require('path');
+
+const isWatch = process.argv.includes('--watch');
+
+const outDir = path.join(__dirname, 'out');
+const webviewOutDir = path.join(outDir, 'webview-ui');
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function copyStaticAssets() {
+  ensureDir(webviewOutDir);
+  const srcHtml = path.join(__dirname, 'webview-ui', 'index.html');
+  const destHtml = path.join(webviewOutDir, 'index.html');
+  fs.copyFileSync(srcHtml, destHtml);
+}
+
+async function build() {
+  ensureDir(outDir);
+  copyStaticAssets();
+
+  const extensionContext = await esbuild.context({
+    bundle: true,
+    entryPoints: [path.join(__dirname, 'src', 'extension.ts')],
+    outfile: path.join(outDir, 'extension.js'),
+    platform: 'node',
+    format: 'cjs',
+    sourcemap: true,
+    external: ['vscode'],
+    target: 'node18',
+    logLevel: 'info',
+  });
+
+  const webviewContext = await esbuild.context({
+    bundle: true,
+    entryPoints: [path.join(__dirname, 'webview-ui', 'index.tsx')],
+    outfile: path.join(webviewOutDir, 'bundle.js'),
+    platform: 'browser',
+    format: 'esm',
+    sourcemap: true,
+    target: 'es2020',
+    loader: {
+      '.png': 'dataurl',
+      '.svg': 'dataurl',
+      '.css': 'css',
+    },
+    define: {
+      'process.env.NODE_ENV': JSON.stringify(isWatch ? 'development' : 'production'),
+    },
+    logLevel: 'info',
+  });
+
+  if (isWatch) {
+    await extensionContext.watch();
+    await webviewContext.watch();
+
+    const htmlPath = path.join(__dirname, 'webview-ui', 'index.html');
+    fs.watch(htmlPath, { persistent: true }, () => {
+      try {
+        copyStaticAssets();
+        console.log('[copy] webview-ui/index.html');
+      } catch (error) {
+        console.error('Failed to copy index.html', error);
+      }
+    });
+
+    console.log('Watching for changes...');
+  } else {
+    await extensionContext.rebuild();
+    await webviewContext.rebuild();
+    await extensionContext.dispose();
+    await webviewContext.dispose();
+  }
+}
+
+build().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/media/icon.svg
+++ b/media/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#bfdbfe"/>
+      <stop offset="1" stop-color="#60a5fa"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="6" width="40" height="28" rx="4" fill="url(#sky)" stroke="#1d4ed8" stroke-width="2"/>
+  <rect x="10" y="26" width="12" height="12" rx="2" fill="#fbbf24" stroke="#b45309" stroke-width="2"/>
+  <rect x="26" y="20" width="12" height="18" rx="2" fill="#34d399" stroke="#047857" stroke-width="2"/>
+  <circle cx="16" cy="16" r="4" fill="#f97316" stroke="#c2410c" stroke-width="2"/>
+  <circle cx="32" cy="14" r="3" fill="#fef3c7" stroke="#facc15" stroke-width="2"/>
+  <path d="M8 40h32" stroke="#1f2937" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "code-plaza",
+  "displayName": "Code Plaza",
+  "description": "A playful virtual plaza that keeps your team visible inside VS Code.",
+  "version": "0.0.1",
+  "publisher": "code-plaza",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:code-plaza.openPlaza"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "code-plaza.openPlaza",
+        "title": "Code Plaza: Open Plaza",
+        "category": "Code Plaza"
+      }
+    ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "codePlaza",
+          "title": "Code Plaza",
+          "icon": "media/icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "codePlaza": [
+        {
+          "id": "codePlazaView",
+          "name": "Code Plaza"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "build": "node esbuild.config.js",
+    "watch": "node esbuild.config.js --watch",
+    "lint": "tsc --noEmit",
+    "package": "npm run build && vsce package"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@types/vscode": "^1.85.0",
+    "esbuild": "^0.19.12",
+    "typescript": "^5.4.5",
+    "vsce": "^2.14.0"
+  },
+  "dependencies": {
+    "firebase": "^10.7.2",
+    "nanoid": "^4.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,238 @@
+import * as vscode from 'vscode';
+import { nanoid } from 'nanoid';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import {
+  createInitialProfile,
+  loadProfile,
+  persistProfile,
+  recordGreeting,
+  subscribeToSessions,
+  touchSession,
+  type StoredProfile,
+} from './firestore';
+import { ExtensionMessenger, mapSessions, type WebviewToExtensionMessage } from './messaging';
+
+const VIEW_ID = 'codePlazaView';
+const COMMAND_ID = 'code-plaza.openPlaza';
+const PROFILE_KEY = 'code-plaza.profile';
+const UID_KEY = 'code-plaza.uid';
+
+export function activate(context: vscode.ExtensionContext) {
+  const provider = new CodePlazaViewProvider(context);
+
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(VIEW_ID, provider, {
+      webviewOptions: { retainContextWhenHidden: true },
+    }),
+    vscode.commands.registerCommand(COMMAND_ID, () => provider.reveal()),
+  );
+}
+
+export function deactivate() {
+  // No-op
+}
+
+class CodePlazaViewProvider implements vscode.WebviewViewProvider {
+  private view?: vscode.WebviewView;
+  private messenger?: ExtensionMessenger;
+  private sessionUnsubscribe?: () => void;
+  private heartbeatTimer?: NodeJS.Timeout;
+  private readonly uid: string;
+  private profile?: StoredProfile;
+
+  constructor(private readonly context: vscode.ExtensionContext) {
+    this.uid = this.loadOrCreateUid();
+    this.profile = context.globalState.get<StoredProfile>(PROFILE_KEY) ?? undefined;
+  }
+
+  reveal(): void {
+    if (this.view) {
+      this.view.show?.(true);
+    } else {
+      void vscode.commands.executeCommand('workbench.view.extension.codePlaza');
+    }
+  }
+
+  async resolveWebviewView(webviewView: vscode.WebviewView): Promise<void> {
+    this.view = webviewView;
+    const webview = webviewView.webview;
+    webview.options = {
+      enableScripts: true,
+      localResourceRoots: [
+        vscode.Uri.joinPath(this.context.extensionUri, 'out'),
+        vscode.Uri.joinPath(this.context.extensionUri, 'media'),
+      ],
+    };
+
+    webview.html = await this.getHtml(webview);
+    this.messenger = new ExtensionMessenger(webview);
+
+    const listener = webview.onDidReceiveMessage((message: WebviewToExtensionMessage) => {
+      void this.handleMessage(message);
+    });
+
+    webview.onDidDispose(() => {
+      listener.dispose();
+      this.stopSession();
+    });
+  }
+
+  private loadOrCreateUid(): string {
+    const stored = this.context.globalState.get<string>(UID_KEY);
+    if (stored) {
+      return stored;
+    }
+    const generated = nanoid(12);
+    void this.context.globalState.update(UID_KEY, generated);
+    return generated;
+  }
+
+  private async getHtml(webview: vscode.Webview): Promise<string> {
+    const htmlPath = path.join(this.context.extensionPath, 'out', 'webview-ui', 'index.html');
+    const rawHtml = await fs.readFile(htmlPath, 'utf8');
+    const nonce = generateNonce();
+    const scriptUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.context.extensionUri, 'out', 'webview-ui', 'bundle.js'),
+    );
+
+    return rawHtml
+      .replace(/\{\{cspSource\}\}/g, webview.cspSource)
+      .replace(/\{\{nonce\}\}/g, nonce)
+      .replace('./bundle.js', scriptUri.toString());
+  }
+
+  private async handleMessage(message: WebviewToExtensionMessage): Promise<void> {
+    switch (message.type) {
+      case 'ready':
+        await this.onReady();
+        break;
+      case 'saveProfile':
+        await this.onSaveProfile(createInitialProfile(message.payload));
+        break;
+      case 'requestSessions':
+        await this.startSession();
+        break;
+      case 'greet':
+        await this.onGreet(message.payload.greetedUid);
+        break;
+      case 'heartbeat':
+        await touchSession(this.uid);
+        break;
+      case 'editProfile':
+        this.stopSession();
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async onReady(): Promise<void> {
+    const webState = this.view?.webview;
+    if (!webState || !this.messenger) {
+      return;
+    }
+    if (!this.profile) {
+      try {
+        const remote = await loadProfile(this.uid);
+        if (remote) {
+          this.profile = remote;
+          await this.context.globalState.update(PROFILE_KEY, remote);
+        }
+      } catch (error) {
+        this.postError('プロフィール情報の取得に失敗しました。', error);
+      }
+    }
+    this.messenger.post({ type: 'profile', payload: this.profile ?? null });
+    if (this.profile) {
+      await this.startSession();
+    }
+  }
+
+  private async onSaveProfile(profile: StoredProfile): Promise<void> {
+    this.profile = profile;
+    await this.context.globalState.update(PROFILE_KEY, profile);
+    try {
+      await persistProfile(this.uid, profile);
+      if (this.messenger) {
+        this.messenger.post({ type: 'profileSaved', payload: profile });
+        this.messenger.post({ type: 'profile', payload: profile });
+      }
+      await this.startSession();
+    } catch (error) {
+      this.postError('プロフィールの保存に失敗しました。Firebaseの設定を確認してください。', error);
+    }
+  }
+
+  private async startSession(): Promise<void> {
+    if (!this.profile) {
+      return;
+    }
+    try {
+      await touchSession(this.uid);
+
+      if (!this.sessionUnsubscribe) {
+        this.sessionUnsubscribe = await subscribeToSessions((sessions) => {
+          if (!this.messenger) {
+            return;
+          }
+          this.messenger.post({ type: 'sessions', payload: mapSessions(this.uid, sessions) });
+        });
+      }
+
+      if (this.heartbeatTimer) {
+        clearInterval(this.heartbeatTimer);
+      }
+      this.heartbeatTimer = setInterval(() => {
+        void touchSession(this.uid);
+      }, 60 * 1000);
+    } catch (error) {
+      this.postError('セッションの開始に失敗しました。ネットワーク接続を確認してください。', error);
+    }
+  }
+
+  private stopSession(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = undefined;
+    }
+    if (this.sessionUnsubscribe) {
+      this.sessionUnsubscribe();
+      this.sessionUnsubscribe = undefined;
+    }
+  }
+
+  private async onGreet(greetedUid: string): Promise<void> {
+    if (!this.messenger) {
+      return;
+    }
+    try {
+      const result = await recordGreeting(this.uid, greetedUid);
+      if (result) {
+        this.profile = {
+          ...(this.profile ?? createInitialProfile({})),
+          exp: result.exp,
+          level: result.level,
+        };
+        await this.context.globalState.update(PROFILE_KEY, this.profile);
+        this.messenger.post({ type: 'greetingRecorded', payload: result });
+      }
+    } catch (error) {
+      this.postError('挨拶の記録に失敗しました。', error);
+    }
+  }
+
+  private postError(message: string, error: unknown): void {
+    console.error('[Code Plaza]', message, error);
+    this.messenger?.post({ type: 'error', payload: message });
+  }
+}
+
+function generateNonce(): string {
+  const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  for (let i = 0; i < 16; i += 1) {
+    result += charset.charAt(Math.floor(Math.random() * charset.length));
+  }
+  return result;
+}

--- a/src/firestore.ts
+++ b/src/firestore.ts
@@ -1,0 +1,458 @@
+import { initializeApp, type FirebaseApp } from 'firebase/app';
+import {
+  collection,
+  doc,
+  getDoc,
+  getFirestore,
+  onSnapshot,
+  serverTimestamp,
+  setDoc,
+  Timestamp,
+  updateDoc,
+  type Firestore,
+} from 'firebase/firestore';
+import { getAuth, signInAnonymously, type Auth } from 'firebase/auth';
+
+type SessionState = 'active' | 'sleeping' | 'exit';
+
+export interface StoredProfile {
+  name: string;
+  avatarCode: string;
+  message?: string;
+  exp: number;
+  level: number;
+}
+
+export interface SessionSnapshot {
+  uid: string;
+  lastHeartbeat: string;
+  greetedToday: string[];
+  state: SessionState;
+  profile: StoredProfile;
+}
+
+export interface GreetingResult {
+  exp: number;
+  level: number;
+}
+
+const firebaseConfig = {
+  apiKey: '<YOUR_API_KEY>',
+  authDomain: '<YOUR_PROJECT_ID>.firebaseapp.com',
+  projectId: '<YOUR_PROJECT_ID>',
+  storageBucket: '<YOUR_PROJECT_ID>.appspot.com',
+  messagingSenderId: '<YOUR_SENDER_ID>',
+  appId: '<YOUR_APP_ID>',
+};
+
+const ACTIVE_THRESHOLD_MS = 15 * 60 * 1000;
+const SLEEP_THRESHOLD_MS = 30 * 60 * 1000;
+const GREETING_EXP = 120;
+
+interface FirestoreSession {
+  userRef?: string;
+  lastHeartbeat?: Timestamp | string;
+  greetedToday?: string[];
+  greetedDate?: string;
+}
+
+interface FirestoreUser {
+  name: string;
+  avatar_code: string;
+  level: number;
+  message?: string;
+  exp: number;
+}
+
+interface Backend {
+  initialize(): Promise<void>;
+  loadProfile(uid: string): Promise<StoredProfile | undefined>;
+  saveProfile(uid: string, profile: StoredProfile): Promise<void>;
+  subscribe(callback: (sessions: SessionSnapshot[]) => void): () => void;
+  updateHeartbeat(uid: string): Promise<void>;
+  recordGreeting(uid: string, greetedUid: string): Promise<GreetingResult | undefined>;
+  resetGreetingList(uid: string): Promise<void>;
+}
+
+class MockBackend implements Backend {
+  private profiles = new Map<string, StoredProfile>();
+  private sessions = new Map<string, FirestoreSession>();
+  private listeners = new Set<(sessions: SessionSnapshot[]) => void>();
+
+  async initialize(): Promise<void> {
+    // No-op
+  }
+
+  async loadProfile(uid: string): Promise<StoredProfile | undefined> {
+    return this.profiles.get(uid);
+  }
+
+  async saveProfile(uid: string, profile: StoredProfile): Promise<void> {
+    this.profiles.set(uid, profile);
+    const existing = this.sessions.get(uid) ?? {};
+    this.sessions.set(uid, {
+      ...existing,
+      userRef: `users/${uid}`,
+      lastHeartbeat: new Date().toISOString(),
+      greetedToday: existing.greetedToday ?? [],
+      greetedDate: existing.greetedDate ?? currentDateKey(),
+    });
+    this.emit();
+  }
+
+  subscribe(callback: (sessions: SessionSnapshot[]) => void): () => void {
+    this.listeners.add(callback);
+    callback(this.composeSessions());
+    return () => {
+      this.listeners.delete(callback);
+    };
+  }
+
+  async updateHeartbeat(uid: string): Promise<void> {
+    const session = this.sessions.get(uid) ?? { greetedToday: [], greetedDate: currentDateKey() };
+    const shouldReset = session.greetedDate !== currentDateKey();
+    this.sessions.set(uid, {
+      ...session,
+      lastHeartbeat: new Date().toISOString(),
+      greetedToday: shouldReset ? [] : session.greetedToday ?? [],
+      greetedDate: shouldReset ? currentDateKey() : session.greetedDate,
+      userRef: `users/${uid}`,
+    });
+    this.emit();
+  }
+
+  async recordGreeting(uid: string, greetedUid: string): Promise<GreetingResult | undefined> {
+    const session = this.sessions.get(uid);
+    if (!session) {
+      return undefined;
+    }
+    const today = currentDateKey();
+    if (session.greetedDate !== today) {
+      session.greetedToday = [];
+      session.greetedDate = today;
+    }
+    session.greetedToday = session.greetedToday ?? [];
+    if (!session.greetedToday.includes(greetedUid)) {
+      session.greetedToday.push(greetedUid);
+      const profile = this.profiles.get(uid);
+      if (profile) {
+        profile.exp += GREETING_EXP;
+        profile.level = calculateLevel(profile.exp);
+        this.profiles.set(uid, profile);
+        this.sessions.set(uid, session);
+        this.emit();
+        return { exp: profile.exp, level: profile.level };
+      }
+      this.sessions.set(uid, session);
+      this.emit();
+    }
+    return undefined;
+  }
+
+  async resetGreetingList(uid: string): Promise<void> {
+    const session = this.sessions.get(uid);
+    if (session) {
+      session.greetedToday = [];
+      session.greetedDate = currentDateKey();
+      this.sessions.set(uid, session);
+      this.emit();
+    }
+  }
+
+  private composeSessions(): SessionSnapshot[] {
+    const now = Date.now();
+    const snapshots: SessionSnapshot[] = [];
+    for (const [uid, session] of this.sessions.entries()) {
+      const profile = this.profiles.get(uid);
+      if (!profile || !session.lastHeartbeat) {
+        continue;
+      }
+      const state = resolveState(session.lastHeartbeat, now);
+      if (state === 'exit') {
+        continue;
+      }
+      snapshots.push({
+        uid,
+        lastHeartbeat: typeof session.lastHeartbeat === 'string' ? session.lastHeartbeat : session.lastHeartbeat.toString(),
+        greetedToday: session.greetedToday ?? [],
+        state,
+        profile,
+      });
+    }
+    return snapshots;
+  }
+
+  private emit() {
+    const snapshots = this.composeSessions();
+    for (const listener of this.listeners) {
+      listener(snapshots);
+    }
+  }
+}
+
+class FirebaseBackend implements Backend {
+  private app?: FirebaseApp;
+  private db?: Firestore;
+  private auth?: Auth;
+
+  async initialize(): Promise<void> {
+    this.app = initializeApp(firebaseConfig);
+    this.db = getFirestore(this.app);
+    this.auth = getAuth(this.app);
+    if (!this.auth.currentUser) {
+      await signInAnonymously(this.auth);
+    }
+  }
+
+  private ensureDb(): Firestore {
+    if (!this.db) {
+      throw new Error('Firestore is not initialized.');
+    }
+    return this.db;
+  }
+
+  async loadProfile(uid: string): Promise<StoredProfile | undefined> {
+    const db = this.ensureDb();
+    const userSnap = await getDoc(doc(db, 'users', uid));
+    if (!userSnap.exists()) {
+      return undefined;
+    }
+    const data = userSnap.data() as FirestoreUser;
+    return normalizeProfile(data);
+  }
+
+  async saveProfile(uid: string, profile: StoredProfile): Promise<void> {
+    const db = this.ensureDb();
+    await setDoc(
+      doc(db, 'users', uid),
+      {
+        name: profile.name,
+        avatar_code: profile.avatarCode,
+        message: profile.message ?? '',
+        exp: profile.exp,
+        level: profile.level,
+      },
+      { merge: true },
+    );
+    await setDoc(
+      doc(db, 'sessions', uid),
+      {
+        userRef: `users/${uid}`,
+        lastHeartbeat: serverTimestamp(),
+        greetedToday: [],
+        greetedDate: currentDateKey(),
+      },
+      { merge: true },
+    );
+  }
+
+  subscribe(callback: (sessions: SessionSnapshot[]) => void): () => void {
+    const db = this.ensureDb();
+    const sessionsCol = collection(db, 'sessions');
+    return onSnapshot(sessionsCol, async (snapshot) => {
+      const now = Date.now();
+      const items = await Promise.all(
+        snapshot.docs.map(async (docSnap) => {
+          const data = docSnap.data() as FirestoreSession;
+          const uid = docSnap.id;
+          const userId = data.userRef?.split('/')[1] ?? uid;
+          const userSnap = await getDoc(doc(db, 'users', userId));
+          if (!userSnap.exists()) {
+            return undefined;
+          }
+          const profile = normalizeProfile(userSnap.data() as FirestoreUser);
+          const state = resolveState(data.lastHeartbeat ?? '', now);
+          if (state === 'exit') {
+            return undefined;
+          }
+          return {
+            uid,
+            lastHeartbeat: toIsoString(data.lastHeartbeat),
+            greetedToday: data.greetedToday ?? [],
+            state,
+            profile,
+          } as SessionSnapshot;
+        }),
+      );
+      callback(items.filter(Boolean) as SessionSnapshot[]);
+    });
+  }
+
+  async updateHeartbeat(uid: string): Promise<void> {
+    const db = this.ensureDb();
+    const sessionRef = doc(db, 'sessions', uid);
+    const today = currentDateKey();
+    const snap = await getDoc(sessionRef);
+    const data = snap.exists() ? (snap.data() as FirestoreSession) : undefined;
+    const greetedDate = data?.greetedDate;
+    const greetedToday = greetedDate === today ? data?.greetedToday ?? [] : [];
+    await setDoc(
+      sessionRef,
+      {
+        userRef: `users/${uid}`,
+        lastHeartbeat: serverTimestamp(),
+        greetedToday,
+        greetedDate: today,
+      },
+      { merge: true },
+    );
+  }
+
+  async recordGreeting(uid: string, greetedUid: string): Promise<GreetingResult | undefined> {
+    const db = this.ensureDb();
+    const sessionRef = doc(db, 'sessions', uid);
+    const userRef = doc(db, 'users', uid);
+    const sessionSnap = await getDoc(sessionRef);
+    const sessionData = sessionSnap.exists() ? (sessionSnap.data() as FirestoreSession) : undefined;
+    const greetedToday = new Set(sessionData?.greetedToday ?? []);
+    const today = currentDateKey();
+    const shouldReset = sessionData?.greetedDate !== today;
+    if (shouldReset) {
+      greetedToday.clear();
+    }
+    if (greetedToday.has(greetedUid)) {
+      return undefined;
+    }
+    greetedToday.add(greetedUid);
+
+    await updateDoc(sessionRef, {
+      greetedToday: Array.from(greetedToday),
+      greetedDate: today,
+    });
+
+    const userSnap = await getDoc(userRef);
+    let exp = GREETING_EXP;
+    let level = 1;
+    if (userSnap.exists()) {
+      const data = userSnap.data() as FirestoreUser;
+      exp = (data.exp ?? 0) + GREETING_EXP;
+      level = calculateLevel(exp);
+      await updateDoc(userRef, { exp, level });
+    }
+    return { exp, level };
+  }
+
+  async resetGreetingList(uid: string): Promise<void> {
+    const db = this.ensureDb();
+    await updateDoc(doc(db, 'sessions', uid), {
+      greetedToday: [],
+      greetedDate: currentDateKey(),
+    });
+  }
+}
+
+let backend: Backend | undefined;
+
+function isFirebaseConfigured(): boolean {
+  return !Object.values(firebaseConfig).some((value) => typeof value === 'string' && value.startsWith('<YOUR_'));
+}
+
+async function getBackend(): Promise<Backend> {
+  if (!backend) {
+    if (isFirebaseConfigured()) {
+      const candidate = new FirebaseBackend();
+      try {
+        await candidate.initialize();
+        backend = candidate;
+      } catch (error) {
+        console.warn('[Code Plaza] Failed to initialize Firebase backend, falling back to mock implementation.', error);
+        backend = new MockBackend();
+        await backend.initialize();
+      }
+    } else {
+      backend = new MockBackend();
+      await backend.initialize();
+    }
+  }
+  return backend;
+}
+
+export async function loadProfile(uid: string): Promise<StoredProfile | undefined> {
+  const service = await getBackend();
+  return service.loadProfile(uid);
+}
+
+export async function persistProfile(uid: string, profile: StoredProfile): Promise<void> {
+  const service = await getBackend();
+  await service.saveProfile(uid, profile);
+}
+
+export async function subscribeToSessions(callback: (sessions: SessionSnapshot[]) => void): Promise<() => void> {
+  const service = await getBackend();
+  return service.subscribe(callback);
+}
+
+export async function touchSession(uid: string): Promise<void> {
+  const service = await getBackend();
+  await service.updateHeartbeat(uid);
+}
+
+export async function recordGreeting(uid: string, greetedUid: string): Promise<GreetingResult | undefined> {
+  const service = await getBackend();
+  return service.recordGreeting(uid, greetedUid);
+}
+
+export async function resetGreetings(uid: string): Promise<void> {
+  const service = await getBackend();
+  await service.resetGreetingList(uid);
+}
+
+export function createInitialProfile(partial: Partial<StoredProfile>): StoredProfile {
+  return {
+    name: partial.name ?? '',
+    avatarCode: partial.avatarCode ?? 'apple',
+    message: partial.message ?? '',
+    exp: partial.exp ?? 0,
+    level: partial.level ?? 1,
+  };
+}
+
+export function calculateLevel(exp: number): number {
+  const base = 300;
+  return Math.max(1, Math.floor(exp / base) + 1);
+}
+
+function resolveState(lastHeartbeat: Timestamp | string | undefined, nowMs: number): SessionState {
+  if (!lastHeartbeat) {
+    return 'exit';
+  }
+  const heartbeatMs = typeof lastHeartbeat === 'string' ? Date.parse(lastHeartbeat) : lastHeartbeat.toMillis();
+  if (!Number.isFinite(heartbeatMs)) {
+    return 'exit';
+  }
+  const delta = nowMs - heartbeatMs;
+  if (delta <= ACTIVE_THRESHOLD_MS) {
+    return 'active';
+  }
+  if (delta <= SLEEP_THRESHOLD_MS) {
+    return 'sleeping';
+  }
+  return 'exit';
+}
+
+function currentDateKey(): string {
+  const now = new Date();
+  return now.toISOString().split('T')[0];
+}
+
+function toIsoString(value: Timestamp | string | undefined): string {
+  if (!value) {
+    return new Date(0).toISOString();
+  }
+  if (typeof value === 'string') {
+    return new Date(value).toISOString();
+  }
+  return value.toDate().toISOString();
+}
+
+function normalizeProfile(user: FirestoreUser): StoredProfile {
+  return {
+    name: user.name,
+    avatarCode: user.avatar_code,
+    message: user.message,
+    exp: user.exp ?? 0,
+    level: user.level ?? 1,
+  };
+}
+
+export { GREETING_EXP, SessionState };

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,0 +1,63 @@
+import type * as vscode from 'vscode';
+import type { SessionState, SessionSnapshot, StoredProfile } from './firestore';
+
+export interface ExtensionState {
+  profile?: StoredProfile;
+  greetedToday?: string[];
+}
+
+export type ExtensionToWebviewMessage =
+  | { type: 'profile'; payload: StoredProfile | null }
+  | { type: 'profileSaved'; payload: StoredProfile }
+  | { type: 'sessions'; payload: SessionPayload }
+  | { type: 'greetingRecorded'; payload: GreetingPayload }
+  | { type: 'error'; payload: string };
+
+export type WebviewToExtensionMessage =
+  | { type: 'ready' }
+  | { type: 'saveProfile'; payload: StoredProfile }
+  | { type: 'requestSessions' }
+  | { type: 'greet'; payload: { greetedUid: string } }
+  | { type: 'heartbeat' }
+  | { type: 'editProfile' };
+
+export interface SessionPayload {
+  selfUid: string;
+  sessions: Array<{
+    uid: string;
+    name: string;
+    avatarCode: string;
+    message?: string;
+    level: number;
+    exp: number;
+    state: SessionState;
+  }>;
+}
+
+export interface GreetingPayload {
+  exp: number;
+  level: number;
+}
+
+export class ExtensionMessenger {
+  constructor(private readonly webview: vscode.Webview) {}
+
+  post(message: ExtensionToWebviewMessage): void {
+    this.webview.postMessage(message);
+  }
+}
+
+export function mapSessions(selfUid: string, snapshots: SessionSnapshot[]): SessionPayload {
+  return {
+    selfUid,
+    sessions: snapshots.map((item) => ({
+      uid: item.uid,
+      name: item.profile.name,
+      avatarCode: item.profile.avatarCode,
+      message: item.profile.message,
+      level: item.profile.level,
+      exp: item.profile.exp,
+      state: item.state,
+    })),
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "types": ["node", "vscode"],
+    "resolveJsonModule": true,
+    "outDir": "out"
+  },
+  "include": ["src", "webview-ui"],
+  "exclude": ["node_modules", "out"]
+}

--- a/webview-ui/assets.d.ts
+++ b/webview-ui/assets.d.ts
@@ -1,0 +1,9 @@
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.png' {
+  const content: string;
+  export default content;
+}

--- a/webview-ui/assets/apple.svg
+++ b/webview-ui/assets/apple.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="appleBody" cx="50%" cy="40%" r="60%">
+      <stop offset="0" stop-color="#ffefc2"/>
+      <stop offset="0.5" stop-color="#ff9b4a"/>
+      <stop offset="1" stop-color="#d9481f"/>
+    </radialGradient>
+  </defs>
+  <path fill="url(#appleBody)" d="M32 8c-11.6 0-20 9.5-20 21.1 0 9.7 5.6 17.3 12.5 21.5C27.1 53.5 29.5 56 32 56s4.9-2.5 7.5-5.4C46.4 46.4 52 38.8 52 29.1 52 17.5 43.6 8 32 8z"/>
+  <path fill="#2f6b2f" d="M30.2 8.2C30.1 5.4 31 3 32.5 2c3.4-2.3 8.1-.3 10 3.6-2.8-.4-5.6 1.1-7.2 3.6-1.4 2.1-3.4 3.2-5.1 2.6z"/>
+  <path fill="#2f6b2f" d="M32 8c2.1-4.5 5.4-6.5 9.1-5.5 1.7 4.6-1.7 9.1-6.8 10-1.2.2-2.4-.2-3.3-1z"/>
+  <ellipse cx="22" cy="32" rx="4" ry="6" fill="#ffe6cf" opacity="0.5"/>
+</svg>

--- a/webview-ui/assets/cat.svg
+++ b/webview-ui/assets/cat.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="36" r="22" fill="#f2c49b" stroke="#a05f2b" stroke-width="2"/>
+  <path d="M18 20l-8-10 0 12z" fill="#f2c49b" stroke="#a05f2b" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M46 20l8-10v12z" fill="#f2c49b" stroke="#a05f2b" stroke-width="2" stroke-linejoin="round"/>
+  <circle cx="24" cy="36" r="4" fill="#3a2d1f"/>
+  <circle cx="40" cy="36" r="4" fill="#3a2d1f"/>
+  <path d="M26 46c2 2 4 3 6 3s4-1 6-3" stroke="#3a2d1f" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M20 42h4" stroke="#3a2d1f" stroke-width="2" stroke-linecap="round"/>
+  <path d="M44 42h4" stroke="#3a2d1f" stroke-width="2" stroke-linecap="round"/>
+  <path d="M32 32v4" stroke="#3a2d1f" stroke-width="2" stroke-linecap="round"/>
+  <path d="M24 52c2 4 6 6 8 6s6-2 8-6" stroke="#a05f2b" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>

--- a/webview-ui/assets/rocket.svg
+++ b/webview-ui/assets/rocket.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="rocketBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#7dd3fc"/>
+      <stop offset="1" stop-color="#1d4ed8"/>
+    </linearGradient>
+  </defs>
+  <path d="M32 4c-6 6-10 16-10 28 0 6 1 12 3 18h14c2-6 3-12 3-18 0-12-4-22-10-28z" fill="url(#rocketBody)" stroke="#1e3a8a" stroke-width="2"/>
+  <circle cx="32" cy="28" r="8" fill="#1e40af" stroke="#0f172a" stroke-width="2"/>
+  <path d="M22 40l-8 10h12c-1-3-2-6-4-10z" fill="#f97316" stroke="#c2410c" stroke-width="2"/>
+  <path d="M42 40l8 10H38c1-3 2-6 4-10z" fill="#f97316" stroke="#c2410c" stroke-width="2"/>
+  <path d="M28 50l-4 12 8-4 8 4-4-12z" fill="#fbbf24" stroke="#b45309" stroke-width="2"/>
+</svg>

--- a/webview-ui/components/Arena.tsx
+++ b/webview-ui/components/Arena.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import Avatar from './Avatar';
+import type { SessionSummary, StoredProfile } from '../types';
+
+interface ArenaProps {
+  profile: StoredProfile;
+  selfUid: string;
+  sessions: SessionSummary[];
+  onEditProfile: () => void;
+}
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+const GRID_COLUMNS = 10;
+const GRID_ROWS = 6;
+
+function randomPosition(): Position {
+  return { x: Math.floor(Math.random() * GRID_COLUMNS), y: Math.floor(Math.random() * GRID_ROWS) };
+}
+
+function moveWithinGrid(position: Position): Position {
+  const directions: Position[] = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: -1, y: 0 },
+    { x: 0, y: 1 },
+    { x: 0, y: -1 },
+  ];
+  const choice = directions[Math.floor(Math.random() * directions.length)];
+  return {
+    x: Math.max(0, Math.min(GRID_COLUMNS - 1, position.x + choice.x)),
+    y: Math.max(0, Math.min(GRID_ROWS - 1, position.y + choice.y)),
+  };
+}
+
+const Arena: React.FC<ArenaProps> = ({ profile, sessions, selfUid, onEditProfile }) => {
+  const [positions, setPositions] = useState<Record<string, Position>>({});
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setPositions((prev) => {
+      const next: Record<string, Position> = { ...prev };
+      sessions.forEach((session) => {
+        if (!next[session.uid]) {
+          next[session.uid] = randomPosition();
+        }
+      });
+      Object.keys(next).forEach((uid) => {
+        if (!sessions.some((session) => session.uid === uid)) {
+          delete next[uid];
+        }
+      });
+      return next;
+    });
+  }, [sessions]);
+
+  useEffect(() => {
+    const tick = () => {
+      setPositions((prev) => {
+        const next: Record<string, Position> = { ...prev };
+        sessions.forEach((session) => {
+          const current = next[session.uid] ?? randomPosition();
+          next[session.uid] = session.state === 'active' ? moveWithinGrid(current) : current;
+        });
+        return next;
+      });
+      const delay = 1000 + Math.random() * 800;
+      timeoutRef.current = setTimeout(tick, delay);
+    };
+    timeoutRef.current = setTimeout(tick, 1000);
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [sessions]);
+
+  const stats = useMemo(() => {
+    const active = sessions.filter((session) => session.state === 'active');
+    const sleeping = sessions.filter((session) => session.state === 'sleeping');
+    return {
+      total: sessions.length,
+      active: active.length,
+      sleeping: sleeping.length,
+    };
+  }, [sessions]);
+
+  return (
+    <div className="arena-view">
+      <header className="arena-header">
+        <div className="arena-profile">
+          <h1>{profile.name}</h1>
+          <p>
+            レベル {profile.level} ・ 経験値 {profile.exp}
+          </p>
+        </div>
+        <div className="arena-stats">
+          <span>参加者 {stats.total}人</span>
+          <span>活動中 {stats.active}人</span>
+          <span>休憩中 {stats.sleeping}人</span>
+        </div>
+        <button className="secondary" onClick={onEditProfile} type="button">
+          プロフィール編集
+        </button>
+      </header>
+      <main className="arena-grid">
+        {sessions.map((session) => {
+          const position = positions[session.uid] ?? randomPosition();
+          const style: React.CSSProperties = {
+            left: `${((position.x + 0.5) / GRID_COLUMNS) * 100}%`,
+            top: `${((position.y + 0.5) / GRID_ROWS) * 100}%`,
+          };
+          return (
+            <Avatar
+              key={session.uid}
+              uid={session.uid}
+              name={session.name}
+              avatarCode={session.avatarCode}
+              message={session.message}
+              level={session.level}
+              state={session.state}
+              isSelf={session.uid === selfUid}
+              style={style}
+            />
+          );
+        })}
+      </main>
+      <footer className="arena-footer">
+        <p>新しい仲間とすれ違うと経験値がアップします！</p>
+        {sessions.length === 0 && <p>まだ誰もいません。チームメイトが参加するとここに表示されます。</p>}
+      </footer>
+    </div>
+  );
+};
+
+export default Arena;

--- a/webview-ui/components/Avatar.tsx
+++ b/webview-ui/components/Avatar.tsx
@@ -1,0 +1,33 @@
+import React, { useMemo } from 'react';
+import type { SessionState } from '../types';
+import { resolveAvatar, useAvatarOptions } from '../hooks/useAvatars';
+
+interface AvatarProps {
+  uid: string;
+  name: string;
+  avatarCode: string;
+  message?: string;
+  level: number;
+  state: SessionState;
+  isSelf: boolean;
+  style: React.CSSProperties;
+}
+
+const Avatar: React.FC<AvatarProps> = ({ name, avatarCode, message, level, state, isSelf, style }) => {
+  const options = useAvatarOptions();
+  const avatar = useMemo(() => resolveAvatar(avatarCode, options), [avatarCode, options]);
+
+  return (
+    <div className={`avatar-node ${state} ${isSelf ? 'self' : ''}`} style={style}>
+      <div className="avatar-wrapper" title={message ?? ''}>
+        <img className="avatar-image" src={avatar.src} alt={name} />
+        {state === 'sleeping' && <span className="avatar-status">💤</span>}
+      </div>
+      <span className="avatar-name">{name}</span>
+      <span className="avatar-level">Lv. {level}</span>
+      {message && <div className="avatar-tooltip">{message}</div>}
+    </div>
+  );
+};
+
+export default Avatar;

--- a/webview-ui/components/Profile.tsx
+++ b/webview-ui/components/Profile.tsx
@@ -1,0 +1,97 @@
+import React, { FormEvent, useMemo, useState } from 'react';
+import type { StoredProfile } from '../types';
+import { useAvatarOptions, resolveAvatar } from '../hooks/useAvatars';
+
+interface ProfileProps {
+  initialProfile: StoredProfile | null;
+  onSubmit: (profile: StoredProfile) => void;
+}
+
+const Profile: React.FC<ProfileProps> = ({ initialProfile, onSubmit }) => {
+  const avatars = useAvatarOptions();
+  const [name, setName] = useState(initialProfile?.name ?? '');
+  const [message, setMessage] = useState(initialProfile?.message ?? '');
+  const [avatarCode, setAvatarCode] = useState(initialProfile?.avatarCode ?? avatars[0]?.code ?? 'apple');
+  const [error, setError] = useState('');
+
+  const preview = useMemo(() => resolveAvatar(avatarCode, avatars), [avatarCode, avatars]);
+
+  const handleSubmit = (event?: FormEvent) => {
+    event?.preventDefault();
+    if (!name.trim()) {
+      setError('名前を入力してください');
+      return;
+    }
+    setError('');
+    onSubmit({
+      name: name.trim(),
+      avatarCode,
+      message: message.trim(),
+      exp: initialProfile?.exp ?? 0,
+      level: initialProfile?.level ?? 1,
+    });
+  };
+
+  return (
+    <div className="profile-view">
+      <div className="profile-card">
+        <h1>はじめまして！</h1>
+        <p className="profile-lead">Code Plaza に参加するためのプロフィールを設定しましょう。</p>
+        <form onSubmit={handleSubmit} className="profile-form">
+          <label className="profile-label" htmlFor="profile-name">
+            名前
+            <input
+              id="profile-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="例: Fujii"
+              required
+            />
+          </label>
+          <label className="profile-label" htmlFor="profile-message">
+            一言コメント
+            <textarea
+              id="profile-message"
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              placeholder="今日の気分を共有しよう！"
+              rows={3}
+            />
+          </label>
+          <fieldset className="avatar-fieldset">
+            <legend>アバターを選択</legend>
+            <div className="avatar-options">
+              {avatars.map((avatar) => (
+                <label key={avatar.code} className={avatar.code === avatarCode ? 'selected' : ''}>
+                  <input
+                    type="radio"
+                    name="avatar"
+                    value={avatar.code}
+                    checked={avatarCode === avatar.code}
+                    onChange={() => setAvatarCode(avatar.code)}
+                  />
+                  <img src={avatar.src} alt={avatar.label} />
+                  <span>{avatar.label}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+          {error && <p className="profile-error">{error}</p>}
+        </form>
+      </div>
+      <div className="profile-preview">
+        <h2>プレビュー</h2>
+        <div className="profile-preview-avatar">
+          <img src={preview.src} alt={preview.label} />
+        </div>
+        <p className="profile-preview-name">{name || 'あなたの名前'}</p>
+        <p className="profile-preview-message">{message || 'ひとことを入力すると、広場で表示されます。'}</p>
+        <button className="primary" onClick={handleSubmit} type="button">
+          広場へ移動
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Profile;

--- a/webview-ui/hooks/useAvatars.ts
+++ b/webview-ui/hooks/useAvatars.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import apple from '../assets/apple.svg';
+import cat from '../assets/cat.svg';
+import rocket from '../assets/rocket.svg';
+
+export interface AvatarOption {
+  code: string;
+  label: string;
+  src: string;
+}
+
+const AVATARS: AvatarOption[] = [
+  { code: 'apple', label: 'アップル', src: apple },
+  { code: 'cat', label: 'キャット', src: cat },
+  { code: 'rocket', label: 'ロケット', src: rocket },
+];
+
+export function useAvatarOptions(): AvatarOption[] {
+  return useMemo(() => AVATARS, []);
+}
+
+export function resolveAvatar(code: string, options: AvatarOption[] = AVATARS): AvatarOption {
+  return options.find((avatar) => avatar.code === code) ?? options[0];
+}

--- a/webview-ui/index.html
+++ b/webview-ui/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; img-src {{cspSource}} https: data:; script-src 'nonce-{{nonce}}'; style-src {{cspSource}} 'unsafe-inline'; connect-src https: {{cspSource}}; font-src {{cspSource}} https: data:;"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Code Plaza</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" nonce="{{nonce}}" src="./bundle.js"></script>
+  </body>
+</html>

--- a/webview-ui/index.tsx
+++ b/webview-ui/index.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import Profile from './components/Profile';
+import Arena from './components/Arena';
+import type { SessionPayload, ExtensionToWebviewMessage } from '../src/messaging';
+import type { StoredProfile } from './types';
+import type { SessionSummary } from './types';
+import './styles/arena.css';
+
+interface VsCodeApi<State = unknown> {
+  postMessage(message: unknown): void;
+  setState(state: State): void;
+  getState(): State | undefined;
+}
+
+declare function acquireVsCodeApi<State = unknown>(): VsCodeApi<State>;
+
+interface AppState {
+  profile: StoredProfile | null;
+}
+
+const vscode = acquireVsCodeApi<AppState>();
+
+type Screen = 'profile' | 'arena';
+
+const App: React.FC = () => {
+  const savedState = vscode.getState();
+  const [profile, setProfile] = useState<StoredProfile | null>(savedState?.profile ?? null);
+  const [screen, setScreen] = useState<Screen>(profile ? 'arena' : 'profile');
+  const [sessions, setSessions] = useState<SessionPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [greetedToday, setGreetedToday] = useState<string[]>([]);
+
+  useEffect(() => {
+    vscode.postMessage({ type: 'ready' });
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent<ExtensionToWebviewMessage>) => {
+      const { data } = event;
+      switch (data.type) {
+        case 'profile':
+          if (data.payload) {
+            setProfile(data.payload);
+            vscode.setState({ profile: data.payload });
+            setScreen('arena');
+            setGreetedToday([]);
+          } else {
+            setProfile(null);
+            vscode.setState({ profile: null });
+            setScreen('profile');
+            setGreetedToday([]);
+          }
+          break;
+        case 'profileSaved':
+          setProfile(data.payload);
+          vscode.setState({ profile: data.payload });
+          setScreen('arena');
+          setGreetedToday([]);
+          break;
+        case 'sessions':
+          setSessions(data.payload);
+          break;
+        case 'greetingRecorded':
+          setProfile((prev) => (prev ? { ...prev, exp: data.payload.exp, level: data.payload.level } : prev));
+          break;
+        case 'error':
+          setError(data.payload);
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, []);
+
+  useEffect(() => {
+    if (!sessions) {
+      return;
+    }
+    const activeMembers = sessions.sessions.filter(
+      (session) => session.state === 'active' && session.uid !== sessions.selfUid,
+    );
+    if (activeMembers.length === 0) {
+      return;
+    }
+    const newGreetings = activeMembers
+      .map((session) => session.uid)
+      .filter((uid) => !greetedToday.includes(uid));
+    if (newGreetings.length === 0) {
+      return;
+    }
+    newGreetings.forEach((uid) => {
+      vscode.postMessage({ type: 'greet', payload: { greetedUid: uid } });
+    });
+    setGreetedToday((prev) => Array.from(new Set([...prev, ...newGreetings])));
+  }, [sessions, greetedToday]);
+
+  useEffect(() => {
+    if (screen === 'arena') {
+      vscode.postMessage({ type: 'requestSessions' });
+    }
+  }, [screen]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      vscode.postMessage({ type: 'heartbeat' });
+    }, 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleProfileSubmit = (profileData: StoredProfile) => {
+    vscode.postMessage({ type: 'saveProfile', payload: profileData });
+  };
+
+  const handleEditProfile = () => {
+    setScreen('profile');
+    vscode.postMessage({ type: 'editProfile' });
+  };
+
+  const arenaSessions: SessionSummary[] = useMemo(() => sessions?.sessions ?? [], [sessions]);
+
+  return (
+    <div className="app">
+      {error && <div className="error-banner">{error}</div>}
+      {screen === 'profile' && <Profile initialProfile={profile} onSubmit={handleProfileSubmit} />}
+      {screen === 'arena' && profile && sessions && (
+        <Arena
+          profile={profile}
+          selfUid={sessions.selfUid}
+          sessions={arenaSessions}
+          onEditProfile={handleEditProfile}
+        />
+      )}
+    </div>
+  );
+};
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/webview-ui/styles/arena.css
+++ b/webview-ui/styles/arena.css
@@ -1,0 +1,319 @@
+:root {
+  color-scheme: light dark;
+}
+
+body,
+html,
+#root,
+.app {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-family: var(--vscode-font-family, 'Segoe UI', sans-serif);
+  color: var(--vscode-foreground);
+  background: var(--vscode-editor-background);
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+}
+
+button {
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+button.primary {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--vscode-button-foreground);
+  border: 1px solid var(--vscode-button-border, var(--vscode-button-background));
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+.error-banner {
+  padding: 8px 12px;
+  background: var(--vscode-inputValidation-errorBackground);
+  color: var(--vscode-inputValidation-errorForeground);
+  border-bottom: 1px solid var(--vscode-inputValidation-errorBorder);
+}
+
+/* Profile view */
+.profile-view {
+  display: flex;
+  flex: 1;
+  gap: 24px;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.profile-card,
+.profile-preview {
+  flex: 1;
+  background: var(--vscode-sideBar-background);
+  border: 1px solid var(--vscode-editorGroup-border);
+  border-radius: 12px;
+  padding: 24px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile-card h1 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.profile-lead {
+  margin: 0;
+  color: var(--vscode-descriptionForeground);
+}
+
+.profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile-label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.profile-label input,
+.profile-label textarea {
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid var(--vscode-input-border, transparent);
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  font-size: 14px;
+}
+
+.avatar-fieldset {
+  border: 1px solid var(--vscode-editorGroup-border);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.avatar-options {
+  display: flex;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.avatar-options label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.avatar-options label.selected {
+  border: 1px solid var(--vscode-focusBorder);
+  transform: translateY(-2px);
+}
+
+.avatar-options img {
+  width: 48px;
+  height: 48px;
+  image-rendering: pixelated;
+}
+
+.avatar-options input {
+  display: none;
+}
+
+.profile-error {
+  color: var(--vscode-inputValidation-errorForeground);
+  margin: 0;
+}
+
+.profile-preview {
+  align-items: center;
+  text-align: center;
+}
+
+.profile-preview-avatar img {
+  width: 72px;
+  height: 72px;
+  image-rendering: pixelated;
+}
+
+.profile-preview-name {
+  font-size: 18px;
+  font-weight: bold;
+  margin: 0;
+}
+
+.profile-preview-message {
+  color: var(--vscode-descriptionForeground);
+  margin: 0;
+}
+
+/* Arena */
+.arena-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
+}
+
+.arena-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 24px;
+  background: var(--vscode-sideBar-background);
+  border-bottom: 1px solid var(--vscode-editorGroup-border);
+}
+
+.arena-profile h1 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.arena-profile p {
+  margin: 4px 0 0;
+  color: var(--vscode-descriptionForeground);
+}
+
+.arena-stats {
+  display: flex;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.arena-grid {
+  position: relative;
+  flex: 1;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.1));
+  border: 1px solid var(--vscode-editorGroup-border);
+  margin: 16px 24px;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.arena-grid::before,
+.arena-grid::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-size: calc(100% / 10) calc(100% / 6);
+  pointer-events: none;
+}
+
+.arena-grid::before {
+  background-image: linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.05) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+}
+
+.arena-grid::after {
+  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.08) 0, transparent 40%);
+  opacity: 0.3;
+}
+
+.avatar-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  transition: left 0.6s ease, top 0.6s ease;
+}
+
+.avatar-node.self .avatar-image {
+  box-shadow: 0 0 0 3px var(--vscode-focusBorder);
+}
+
+.avatar-wrapper {
+  position: relative;
+}
+
+.avatar-image {
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+  background: var(--vscode-editor-background);
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+  image-rendering: pixelated;
+}
+
+.avatar-status {
+  position: absolute;
+  right: -8px;
+  bottom: -8px;
+  font-size: 20px;
+}
+
+.avatar-name {
+  font-weight: 600;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+.avatar-level {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.avatar-tooltip {
+  position: absolute;
+  bottom: 72px;
+  min-width: 160px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 8px 12px;
+  border-radius: 8px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(4px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  font-size: 12px;
+}
+
+.avatar-node:hover .avatar-tooltip {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.arena-footer {
+  padding: 12px 24px 24px;
+  color: var(--vscode-descriptionForeground);
+  font-size: 13px;
+}
+
+@media (max-width: 960px) {
+  .profile-view {
+    flex-direction: column;
+  }
+}

--- a/webview-ui/types.ts
+++ b/webview-ui/types.ts
@@ -1,0 +1,19 @@
+export interface StoredProfile {
+  name: string;
+  avatarCode: string;
+  message?: string;
+  exp: number;
+  level: number;
+}
+
+export type SessionState = 'active' | 'sleeping' | 'exit';
+
+export interface SessionSummary {
+  uid: string;
+  name: string;
+  avatarCode: string;
+  message?: string;
+  level: number;
+  exp: number;
+  state: SessionState;
+}


### PR DESCRIPTION
## Summary
- add the Code Plaza VS Code extension entry point with session management and Firestore-backed persistence (including an offline mock fallback)
- implement the React-based webview UI for the profile editor and animated plaza arena with reusable avatar components
- configure build tooling, assets, and project documentation for local development and packaging
- replace plaza avatars and the activity bar icon with SVG artwork and wire up loaders/typings for the new asset format

## Testing
- npm install *(fails: registry access blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d1cf829a8483238c8451eca59b9f8d